### PR TITLE
Output rollbar project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.2
+
+- [Output rollbar project](https://github.com/babbel/terraform-aws-secretsmanager-for-rollbar-access-tokens/pull/5)
+
+
 ## v1.0.1
 
 - [Fix Readme](https://github.com/babbel/terraform-aws-secretsmanager-for-rollbar-access-tokens/pull/2)

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,9 @@
+output "rollbar_project" {
+  value = data.rollbar_project.this
+
+  description = "The Rollbar project."
+}
+
 output "secretsmanager_secret" {
   value = aws_secretsmanager_secret.this
 


### PR DESCRIPTION
Replaces https://github.com/babbel/terraform-aws-secretsmanager-for-rollbar-access-tokens/pull/4.