### PR TITLE
Bump Rollbar provider dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.3
+
+- [Bump Rollbar provider dependency](https://github.com/babbel/terraform-aws-secretsmanager-for-rollbar-access-tokens/pull/8)
+
 ## v1.0.2
 
 - [Output rollbar project](https://github.com/babbel/terraform-aws-secretsmanager-for-rollbar-access-tokens/pull/5)

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     rollbar = {
       source  = "rollbar/rollbar"
-      version = "~> 1.0.6"
+      version = "~> 1.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     rollbar = {
       source  = "rollbar/rollbar"
-      version = "1.0.2"
+      version = "~> 1.0.6"
     }
   }
 }


### PR DESCRIPTION
In a module using this child module, upgrading the provider is currently not possible without this change, and we'd like to unblock future upgrades as well.