### PR TITLE
Add support for resource-specific tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,6 @@ module "secretsmanager-for-rollbar-access-tokens" {
   name_prefix = "example"
 
   rollbar_tokens = values(rollbar_project_access_token.example)
-
-  tags = {
-    app = "example"
-    env = "production"
-  }
 }
 ```
 

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -22,7 +22,7 @@ module "secretsmanager" {
 
   rollbar_tokens = local.rollbar_tokens
 
-  tags = {
+  default_tags = {
     app = "example"
     env = "production"
   }

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ resource "aws_secretsmanager_secret" "this" {
   name        = "${var.name_prefix}.rollbar_access_tokens"
   description = "Secret value is managed via Terraform"
 
-  tags = var.tags
+  tags = merge(var.default_tags, var.secretsmanager_secret_tags)
 }
 
 resource "aws_secretsmanager_secret_version" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,14 +1,18 @@
-variable "name_prefix" {
-  type = string
-
-  description = "Name prefix for the SecretsManager. The full name will be $${var.name_prefix}.rollbar_access_tokens."
-}
-
-variable "tags" {
+variable "default_tags" {
   type    = map(string)
   default = {}
 
-  description = "Tags which will be assigned to all resources."
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
+variable "name_prefix" {
+  type = string
+
+  description = <<EOS
+Name prefix for the SecretsManager. The full name will be $${var.name_prefix}.rollbar_access_tokens.
+EOS
 }
 
 variable "rollbar_tokens" {
@@ -17,5 +21,16 @@ variable "rollbar_tokens" {
     access_token = string
   }))
 
-  description = "List of objects having access tokens names and the token values which shall be loaded into the SecretsManager."
+  description = <<EOS
+List of objects having access tokens names and the token values which shall be loaded into the SecretsManager.
+EOS
+}
+
+variable "secretsmanager_secret_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the SecretsManager secret.
+EOS
 }


### PR DESCRIPTION
Breaking change: Renaming `var.tags` to `var.default_tag` in order to make it clearer that those are tags are applied to all AWS resources.