### PR TITLE
Breaking change: Rename `var.tags` to `var.default_tags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,6 @@ module "secretsmanager-for-rollbar-access-tokens" {
   name_prefix = "example"
 
   rollbar_tokens = values(rollbar_project_access_token.example)
-
-  tags = {
-    app = "example"
-    env = "production"
-  }
 }
 ```
 

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -22,7 +22,7 @@ module "secretsmanager" {
 
   rollbar_tokens = local.rollbar_tokens
 
-  tags = {
+  default_tags = {
     app = "example"
     env = "production"
   }

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ resource "aws_secretsmanager_secret" "this" {
   name        = "${var.name_prefix}.rollbar_access_tokens"
   description = "Secret value is managed via Terraform"
 
-  tags = var.tags
+  tags = var.default_tags
 }
 
 resource "aws_secretsmanager_secret_version" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,12 @@
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
 variable "name_prefix" {
   type = string
 
@@ -14,14 +23,5 @@ variable "rollbar_tokens" {
 
   description = <<EOS
 List of objects having access tokens names and the token values which shall be loaded into the SecretsManager.
-EOS
-}
-
-variable "tags" {
-  type    = map(string)
-  default = {}
-
-  description = <<EOS
-Map of tags assigned to all AWS resources created by this module.
 EOS
 }


### PR DESCRIPTION
This change is done to make it more clear, that tags specified via this attribute will be assigned to all AWS resources created by this module.

Also drop this attribute from the usage example in the `README.md`, as this attribute is rather for edge cases, as default tags typically specified via the `default_tags` block of the AWS provider.